### PR TITLE
Remove weird statistics

### DIFF
--- a/content/blog/2024-08-12-transition-announcement.md
+++ b/content/blog/2024-08-12-transition-announcement.md
@@ -180,9 +180,7 @@ Our immediate focus is on the following tasks:
 - **Better compatibility.**
   - Fully switch to [quasi-pointers](https://github.com/EmbarkStudios/spirt/pull/24) to
     support more advanced Rust constructs.
-  - Add `alloc` support. This will allow us to move from supporting [at most 500
-    `no_std`, no alloc crates](https://crates.io/categories/no-std::no-alloc) to [over
-    6,000 `no_std` + alloc crates](https://crates.io/categories/no-std).
+  - Add `alloc` support. This will allow us to use even more `no_std` crates that also allocate memory.
 - **Better testing.**
   - Develop our own crater-like tool to create a burndown list of `no_std` and `alloc`
     crates that don't work with Rust GPU.


### PR DESCRIPTION
The crates.io stats are misleading because it's a *very* incomplete list. I have no idea how crates.io defines these categories, but none of my no-std no-alloc crates are listed.

I feel like listing this with such a small number of crates does a disservice to the community that has been working on making a great no-std ecosystem.

Hence this PR. Let's keep it more vague while still making the point. Thanks!