### PR TITLE
Do not break up inline codeblocks

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -77,6 +77,7 @@
 
   code {
     @apply text-code bg-code-background;
+    @apply whitespace-pre;
   }
 
   hr {


### PR DESCRIPTION
Before on left, after on right.

<img width="981" alt="Screenshot 2024-11-28 at 9 25 16 AM" src="https://github.com/user-attachments/assets/2f5ace2f-18fb-483a-8058-92bdea77b45a">
