### PR TITLE
Use a relative error, as a hardcoded one drifts when floats are large.

### DIFF
--- a/blog/2024-11-25-optimizing-matmul/code/bin/blog/src/bin.rs
+++ b/blog/2024-11-25-optimizing-matmul/code/bin/blog/src/bin.rs
@@ -183,8 +183,9 @@ fn verify_results(a: &[f32], b: &[f32], result: &[f32], m: u32, k: u32, n: u32) 
             }
             let actual = result[(i * n + j) as usize];
             let diff = (actual - expected).abs();
+            let rel_error = diff / expected.abs();
             assert!(
-                diff < 1e-3,
+                rel_error < 1e-3,
                 "Mismatch at [{}, {}]: expected {}, got {}",
                 i,
                 j,


### PR DESCRIPTION
Fixes https://github.com/Rust-GPU/rust-gpu.github.io/issues/73.