### PR TITLE
Fix monospace font fallback

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,7 +24,7 @@ module.exports = {
       fontFamily: {
         header: ['"Geist"', "sans-serif"],
         text: ['"Geist"', "sans-serif"],
-        mono: ['"GeistMono"', "sans-serif"],
+        mono: ['"GeistMono"', "monospace"],
       },
       borderWidth: {
         thin: "max(1px, 0.0625rem)",


### PR DESCRIPTION
`monospace` is more correct that `sans-serif` for "GeistMono". It renders better for mobile readers who adblock all fonts. This doesn't affect normal readers.